### PR TITLE
 Fix `strict-provenance` error in `swap()`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1215,10 +1215,11 @@ impl<const N: usize, T> CircularBuffer<N, T> {
     pub fn swap(&mut self, i: usize, j: usize) {
         assert!(i < self.size, "i index out-of-bounds");
         assert!(j < self.size, "j index out-of-bounds");
-        // SAFETY: these are valid pointers
-        unsafe {
-            ptr::swap(self.get_maybe_uninit(i) as *const MaybeUninit<T> as *mut MaybeUninit<T>,
-                      self.get_maybe_uninit(j) as *const MaybeUninit<T> as *mut MaybeUninit<T>);
+        if i != j {
+            let i = add_mod(self.start, i, N);
+            let j = add_mod(self.start, j, N);
+            // SAFETY: these are valid pointers
+            unsafe { ptr::swap(&mut self.items[i], &mut self.items[j]) };
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,7 +1219,7 @@ impl<const N: usize, T> CircularBuffer<N, T> {
             let i = add_mod(self.start, i, N);
             let j = add_mod(self.start, j, N);
             // SAFETY: these are valid pointers
-            unsafe { ptr::swap(&mut self.items[i], &mut self.items[j]) };
+            unsafe { ptr::swap_nonoverlapping(&mut self.items[i], &mut self.items[j], 1) };
         }
     }
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1090,7 +1090,10 @@ fn clone() {
 
 #[test]
 fn large_boxed() {
+    #[cfg(not(miri))]
     const SIZE: usize = 2 * 1024 * 1024; // 2 MiB
+    #[cfg(miri)]
+    const SIZE: usize = 2 * 1024; // 2 kiB
     let chunk = b"abcdefghijklmnopqrstuvxyz0123456789";
     let mut buf = CircularBuffer::<SIZE, u8>::boxed();
     let mut vec = Vec::new();
@@ -1250,4 +1253,25 @@ fn add_mod() {
         assert_add_mod_eq!(m - 2, crate::add_mod(m - 2, m, m));
         assert_add_mod_eq!(m - 1, crate::add_mod(m - 1, m, m));
     }
+}
+
+#[test]
+fn swap() {
+    let mut buf: CircularBuffer<4, u32> = [1,2,3,4].into_iter().collect();
+    buf.swap(0, 3);
+    assert_eq!(buf.to_vec(), vec![4, 2, 3, 1]);
+    buf.swap(1, 2);
+    assert_eq!(buf.to_vec(), vec![4, 3, 2, 1]);
+    buf.pop_front();
+    assert_eq!(buf.to_vec(), vec![3, 2, 1]);
+    buf.push_back(4);
+    assert_eq!(buf.to_vec(), vec![3, 2, 1, 4]);
+    buf.swap(0, 1);
+    assert_eq!(buf.to_vec(), vec![2, 3, 1, 4]);
+    buf.swap(1, 2);
+    assert_eq!(buf.to_vec(), vec![2, 1, 3, 4]);
+    buf.swap(2, 3);
+    assert_eq!(buf.to_vec(), vec![2, 1, 4, 3]);
+    buf.swap(3, 0);
+    assert_eq!(buf.to_vec(), vec![3, 1, 4, 2]);
 }


### PR DESCRIPTION
The call to `get_maybe_uninit()` was wrong, because a cast from `&const _` to `&mut _` is UB. But also a using `get_maybe_uninit_mut()` would be wrong, because the second invocation of the method invalidates the exclusive borrow of the first call.

This change inlines the functionality of `get_maybe_uninit_mut()`, to fix the problem. It can be tested with:

```sh
MIRIFLAGS="-Zmiri-strict-provenance" cargo +nightly miri test
```