### PR TITLE
Make `push_back` and `push_front` return the discarded value (if any)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1036,16 +1036,12 @@ impl<const N: usize, T> CircularBuffer<N, T> {
             // At capacity; need to replace the front item
             //
             // SAFETY: if size is greater than 0, the front item is guaranteed to be initialized.
-            let old_value = unsafe {
-                mem::replace(self.front_maybe_uninit_mut()
-                                 .as_mut_ptr()
-                                 .as_mut()
-                                 .expect("pointer is valid"),
-                             item)
-            };
+            let replaced_item = mem::replace(
+                unsafe { self.front_maybe_uninit_mut().assume_init_mut() },
+                item);
             self.inc_start();
 
-            Some(old_value)
+            Some(replaced_item)
         } else {
             // Some uninitialized slots left; append at the end
             self.inc_size();
@@ -1087,16 +1083,12 @@ impl<const N: usize, T> CircularBuffer<N, T> {
             // At capacity; need to replace the back item
             //
             // SAFETY: if size is greater than 0, the back item is guaranteed to be initialized.
-            let old_value = unsafe {
-                mem::replace(self.back_maybe_uninit_mut()
-                                 .as_mut_ptr()
-                                 .as_mut()
-                                 .expect("pointer is valid"),
-                             item)
-            };
+            let replaced_item = mem::replace(
+                unsafe { self.back_maybe_uninit_mut().assume_init_mut() },
+                item);
             self.dec_start();
 
-            Some(old_value)
+            Some(replaced_item)
         } else {
             // Some uninitialized slots left; insert at the start
             self.inc_size();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1006,9 +1006,7 @@ impl<const N: usize, T> CircularBuffer<N, T> {
 
     /// Appends an element to the back of the buffer.
     ///
-    /// If the buffer is full, the element at the front of the buffer is replaced.
-    ///
-    /// Returns the replaced value if it had to replace an element to make room, or `None` if not.
+    /// If the buffer is full, the element at the front of the buffer is removed and returned.
     ///
     /// # Examples
     ///
@@ -1017,11 +1015,11 @@ impl<const N: usize, T> CircularBuffer<N, T> {
     ///
     /// let mut buf = CircularBuffer::<3, char>::new();
     ///
-    /// assert_eq!(buf.push_back('a'), None); assert_eq!(buf, ['a']);
-    /// assert_eq!(buf.push_back('b'), None); assert_eq!(buf, ['a', 'b']);
-    /// assert_eq!(buf.push_back('c'), None); assert_eq!(buf, ['a', 'b', 'c']);
-    /// // The buffer is now full; adding more values causes the front elements to be replaced
-    /// // From here on, `push_back` will return the replaced value
+    /// assert_eq!(buf.push_back('a'), None);      assert_eq!(buf, ['a']);
+    /// assert_eq!(buf.push_back('b'), None);      assert_eq!(buf, ['a', 'b']);
+    /// assert_eq!(buf.push_back('c'), None);      assert_eq!(buf, ['a', 'b', 'c']);
+    /// // The buffer is now full; adding more values causes the front elements to be
+    /// // removed and returned
     /// assert_eq!(buf.push_back('d'), Some('a')); assert_eq!(buf, ['b', 'c', 'd']);
     /// assert_eq!(buf.push_back('e'), Some('b')); assert_eq!(buf, ['c', 'd', 'e']);
     /// assert_eq!(buf.push_back('f'), Some('c')); assert_eq!(buf, ['d', 'e', 'f']);
@@ -1053,9 +1051,7 @@ impl<const N: usize, T> CircularBuffer<N, T> {
 
     /// Appends an element to the front of the buffer.
     ///
-    /// If the buffer is full, the element at the back of the buffer is replaced.
-    ///
-    /// Returns the replaced value if it had to replace an element to make room, or `None` if not.
+    /// If the buffer is full, the element at the back of the buffer is removed and returned.
     ///
     /// # Examples
     ///
@@ -1064,11 +1060,11 @@ impl<const N: usize, T> CircularBuffer<N, T> {
     ///
     /// let mut buf = CircularBuffer::<3, char>::new();
     ///
-    /// assert_eq!(buf.push_front('a'), None); assert_eq!(buf, ['a']);
-    /// assert_eq!(buf.push_front('b'), None); assert_eq!(buf, ['b', 'a']);
-    /// assert_eq!(buf.push_front('c'), None); assert_eq!(buf, ['c', 'b', 'a']);
-    /// // The buffer is now full; adding more values causes the back elements to be replaced
-    /// // From here on, `push_front` will return the replaced value
+    /// assert_eq!(buf.push_front('a'), None);      assert_eq!(buf, ['a']);
+    /// assert_eq!(buf.push_front('b'), None);      assert_eq!(buf, ['b', 'a']);
+    /// assert_eq!(buf.push_front('c'), None);      assert_eq!(buf, ['c', 'b', 'a']);
+    /// // The buffer is now full; adding more values causes the back elements to be
+    /// // removed and returned
     /// assert_eq!(buf.push_front('d'), Some('a')); assert_eq!(buf, ['d', 'c', 'b']);
     /// assert_eq!(buf.push_front('e'), Some('b')); assert_eq!(buf, ['e', 'd', 'c']);
     /// assert_eq!(buf.push_front('f'), Some('c')); assert_eq!(buf, ['f', 'e', 'd']);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1027,7 +1027,7 @@ impl<const N: usize, T> CircularBuffer<N, T> {
     pub fn push_back(&mut self, item: T) -> Option<T> {
         if N == 0 {
             // Nothing to do
-            return None;
+            return Some(item);
         }
 
         if self.size >= N {
@@ -1072,7 +1072,7 @@ impl<const N: usize, T> CircularBuffer<N, T> {
     pub fn push_front(&mut self, item: T) -> Option<T> {
         if N == 0 {
             // Nothing to do
-            return None;
+            return Some(item);
         }
 
         if self.size >= N {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -115,22 +115,22 @@ fn push_back() {
     tracker.assert_all_alive([1, 2, 3, 4]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_back(tracker.track(5)).as_deref().map(Clone::clone), Some(1));
+    assert_eq!(buf.push_back(tracker.track(5)).unwrap(), 1);
     assert_buf_eq!(buf, [2, 3, 4, 5]);
     tracker.assert_all_alive([2, 3, 4, 5]);
     tracker.assert_all_dropped([1]);
 
-    assert_eq!(buf.push_back(tracker.track(6)).as_deref().map(Clone::clone), Some(2));
+    assert_eq!(buf.push_back(tracker.track(6)).unwrap(), 2);
     assert_buf_eq!(buf, [3, 4, 5, 6]);
     tracker.assert_all_alive([3, 4, 5, 6]);
     tracker.assert_all_dropped([1, 2]);
 
-    assert_eq!(buf.push_back(tracker.track(7)).as_deref().map(Clone::clone), Some(3));
+    assert_eq!(buf.push_back(tracker.track(7)).unwrap(), 3);
     assert_buf_eq!(buf, [4, 5, 6, 7]);
     tracker.assert_all_alive([4, 5, 6, 7]);
     tracker.assert_all_dropped([1, 2, 3]);
 
-    assert_eq!(buf.push_back(tracker.track(8)).as_deref().map(Clone::clone), Some(4));
+    assert_eq!(buf.push_back(tracker.track(8)).unwrap(), 4);
     assert_buf_eq!(buf, [5, 6, 7, 8]);
     tracker.assert_all_alive([5, 6, 7, 8]);
     tracker.assert_all_dropped([1, 2, 3, 4]);
@@ -162,22 +162,22 @@ fn push_front() {
     tracker.assert_all_alive([1, 2, 3, 4]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_front(tracker.track(5)).as_deref().map(Clone::clone), Some(1));
+    assert_eq!(buf.push_front(tracker.track(5)).unwrap(), 1);
     assert_buf_eq!(buf, [5, 4, 3, 2]);
     tracker.assert_all_alive([2, 3, 4, 5]);
     tracker.assert_all_dropped([1]);
 
-    assert_eq!(buf.push_front(tracker.track(6)).as_deref().map(Clone::clone), Some(2));
+    assert_eq!(buf.push_front(tracker.track(6)).unwrap(), 2);
     assert_buf_eq!(buf, [6, 5, 4, 3]);
     tracker.assert_all_alive([3, 4, 5, 6]);
     tracker.assert_all_dropped([1, 2]);
 
-    assert_eq!(buf.push_front(tracker.track(7)).as_deref().map(Clone::clone), Some(3));
+    assert_eq!(buf.push_front(tracker.track(7)).unwrap(), 3);
     assert_buf_eq!(buf, [7, 6, 5, 4]);
     tracker.assert_all_alive([4, 5, 6, 7]);
     tracker.assert_all_dropped([1, 2, 3]);
 
-    assert_eq!(buf.push_front(tracker.track(8)).as_deref().map(Clone::clone), Some(4));
+    assert_eq!(buf.push_front(tracker.track(8)).unwrap(), 4);
     assert_buf_eq!(buf, [8, 7, 6, 5]);
     tracker.assert_all_alive([5, 6, 7, 8]);
     tracker.assert_all_dropped([1, 2, 3, 4]);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,42 +95,42 @@ fn push_back() {
     let mut buf = CircularBuffer::<4, DropItem<i32>>::new();
     assert_buf_eq!(buf, [] as [i32; 0]);
 
-    assert_eq!(buf.push_back(tracker.track(1)), false);
+    assert_eq!(buf.push_back(tracker.track(1)), None);
     assert_buf_eq!(buf, [1]);
     tracker.assert_all_alive([1]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_back(tracker.track(2)), false);
+    assert_eq!(buf.push_back(tracker.track(2)), None);
     assert_buf_eq!(buf, [1, 2]);
     tracker.assert_all_alive([1, 2]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_back(tracker.track(3)), false);
+    assert_eq!(buf.push_back(tracker.track(3)), None);
     assert_buf_eq!(buf, [1, 2, 3]);
     tracker.assert_all_alive([1, 2, 3]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_back(tracker.track(4)), false);
+    assert_eq!(buf.push_back(tracker.track(4)), None);
     assert_buf_eq!(buf, [1, 2, 3, 4]);
     tracker.assert_all_alive([1, 2, 3, 4]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_back(tracker.track(5)), true);
+    assert_eq!(buf.push_back(tracker.track(5)).as_deref().map(Clone::clone), Some(1));
     assert_buf_eq!(buf, [2, 3, 4, 5]);
     tracker.assert_all_alive([2, 3, 4, 5]);
     tracker.assert_all_dropped([1]);
 
-    assert_eq!(buf.push_back(tracker.track(6)), true);
+    assert_eq!(buf.push_back(tracker.track(6)).as_deref().map(Clone::clone), Some(2));
     assert_buf_eq!(buf, [3, 4, 5, 6]);
     tracker.assert_all_alive([3, 4, 5, 6]);
     tracker.assert_all_dropped([1, 2]);
 
-    assert_eq!(buf.push_back(tracker.track(7)), true);
+    assert_eq!(buf.push_back(tracker.track(7)).as_deref().map(Clone::clone), Some(3));
     assert_buf_eq!(buf, [4, 5, 6, 7]);
     tracker.assert_all_alive([4, 5, 6, 7]);
     tracker.assert_all_dropped([1, 2, 3]);
 
-    assert_eq!(buf.push_back(tracker.track(8)), true);
+    assert_eq!(buf.push_back(tracker.track(8)).as_deref().map(Clone::clone), Some(4));
     assert_buf_eq!(buf, [5, 6, 7, 8]);
     tracker.assert_all_alive([5, 6, 7, 8]);
     tracker.assert_all_dropped([1, 2, 3, 4]);
@@ -142,42 +142,42 @@ fn push_front() {
     let mut buf = CircularBuffer::<4, DropItem<i32>>::new();
     assert_buf_eq!(buf, [] as [i32; 0]);
 
-    assert_eq!(buf.push_front(tracker.track(1)), false);
+    assert_eq!(buf.push_front(tracker.track(1)), None);
     assert_buf_eq!(buf, [1]);
     tracker.assert_all_alive([1]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_front(tracker.track(2)), false);
+    assert_eq!(buf.push_front(tracker.track(2)), None);
     assert_buf_eq!(buf, [2, 1]);
     tracker.assert_all_alive([1, 2]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_front(tracker.track(3)), false);
+    assert_eq!(buf.push_front(tracker.track(3)), None);
     assert_buf_eq!(buf, [3, 2, 1]);
     tracker.assert_all_alive([1, 2, 3]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_front(tracker.track(4)), false);
+    assert_eq!(buf.push_front(tracker.track(4)), None);
     assert_buf_eq!(buf, [4, 3, 2, 1]);
     tracker.assert_all_alive([1, 2, 3, 4]);
     tracker.assert_fully_alive();
 
-    assert_eq!(buf.push_front(tracker.track(5)), true);
+    assert_eq!(buf.push_front(tracker.track(5)).as_deref().map(Clone::clone), Some(1));
     assert_buf_eq!(buf, [5, 4, 3, 2]);
     tracker.assert_all_alive([2, 3, 4, 5]);
     tracker.assert_all_dropped([1]);
 
-    assert_eq!(buf.push_front(tracker.track(6)), true);
+    assert_eq!(buf.push_front(tracker.track(6)).as_deref().map(Clone::clone), Some(2));
     assert_buf_eq!(buf, [6, 5, 4, 3]);
     tracker.assert_all_alive([3, 4, 5, 6]);
     tracker.assert_all_dropped([1, 2]);
 
-    assert_eq!(buf.push_front(tracker.track(7)), true);
+    assert_eq!(buf.push_front(tracker.track(7)).as_deref().map(Clone::clone), Some(3));
     assert_buf_eq!(buf, [7, 6, 5, 4]);
     tracker.assert_all_alive([4, 5, 6, 7]);
     tracker.assert_all_dropped([1, 2, 3]);
 
-    assert_eq!(buf.push_front(tracker.track(8)), true);
+    assert_eq!(buf.push_front(tracker.track(8)).as_deref().map(Clone::clone), Some(4));
     assert_buf_eq!(buf, [8, 7, 6, 5]);
     tracker.assert_all_alive([5, 6, 7, 8]);
     tracker.assert_all_dropped([1, 2, 3, 4]);

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -95,42 +95,42 @@ fn push_back() {
     let mut buf = CircularBuffer::<4, DropItem<i32>>::new();
     assert_buf_eq!(buf, [] as [i32; 0]);
 
-    buf.push_back(tracker.track(1));
+    assert_eq!(buf.push_back(tracker.track(1)), false);
     assert_buf_eq!(buf, [1]);
     tracker.assert_all_alive([1]);
     tracker.assert_fully_alive();
 
-    buf.push_back(tracker.track(2));
+    assert_eq!(buf.push_back(tracker.track(2)), false);
     assert_buf_eq!(buf, [1, 2]);
     tracker.assert_all_alive([1, 2]);
     tracker.assert_fully_alive();
 
-    buf.push_back(tracker.track(3));
+    assert_eq!(buf.push_back(tracker.track(3)), false);
     assert_buf_eq!(buf, [1, 2, 3]);
     tracker.assert_all_alive([1, 2, 3]);
     tracker.assert_fully_alive();
 
-    buf.push_back(tracker.track(4));
+    assert_eq!(buf.push_back(tracker.track(4)), false);
     assert_buf_eq!(buf, [1, 2, 3, 4]);
     tracker.assert_all_alive([1, 2, 3, 4]);
     tracker.assert_fully_alive();
 
-    buf.push_back(tracker.track(5));
+    assert_eq!(buf.push_back(tracker.track(5)), true);
     assert_buf_eq!(buf, [2, 3, 4, 5]);
     tracker.assert_all_alive([2, 3, 4, 5]);
     tracker.assert_all_dropped([1]);
 
-    buf.push_back(tracker.track(6));
+    assert_eq!(buf.push_back(tracker.track(6)), true);
     assert_buf_eq!(buf, [3, 4, 5, 6]);
     tracker.assert_all_alive([3, 4, 5, 6]);
     tracker.assert_all_dropped([1, 2]);
 
-    buf.push_back(tracker.track(7));
+    assert_eq!(buf.push_back(tracker.track(7)), true);
     assert_buf_eq!(buf, [4, 5, 6, 7]);
     tracker.assert_all_alive([4, 5, 6, 7]);
     tracker.assert_all_dropped([1, 2, 3]);
 
-    buf.push_back(tracker.track(8));
+    assert_eq!(buf.push_back(tracker.track(8)), true);
     assert_buf_eq!(buf, [5, 6, 7, 8]);
     tracker.assert_all_alive([5, 6, 7, 8]);
     tracker.assert_all_dropped([1, 2, 3, 4]);
@@ -142,42 +142,42 @@ fn push_front() {
     let mut buf = CircularBuffer::<4, DropItem<i32>>::new();
     assert_buf_eq!(buf, [] as [i32; 0]);
 
-    buf.push_front(tracker.track(1));
+    assert_eq!(buf.push_front(tracker.track(1)), false);
     assert_buf_eq!(buf, [1]);
     tracker.assert_all_alive([1]);
     tracker.assert_fully_alive();
 
-    buf.push_front(tracker.track(2));
+    assert_eq!(buf.push_front(tracker.track(2)), false);
     assert_buf_eq!(buf, [2, 1]);
     tracker.assert_all_alive([1, 2]);
     tracker.assert_fully_alive();
 
-    buf.push_front(tracker.track(3));
+    assert_eq!(buf.push_front(tracker.track(3)), false);
     assert_buf_eq!(buf, [3, 2, 1]);
     tracker.assert_all_alive([1, 2, 3]);
     tracker.assert_fully_alive();
 
-    buf.push_front(tracker.track(4));
+    assert_eq!(buf.push_front(tracker.track(4)), false);
     assert_buf_eq!(buf, [4, 3, 2, 1]);
     tracker.assert_all_alive([1, 2, 3, 4]);
     tracker.assert_fully_alive();
 
-    buf.push_front(tracker.track(5));
+    assert_eq!(buf.push_front(tracker.track(5)), true);
     assert_buf_eq!(buf, [5, 4, 3, 2]);
     tracker.assert_all_alive([2, 3, 4, 5]);
     tracker.assert_all_dropped([1]);
 
-    buf.push_front(tracker.track(6));
+    assert_eq!(buf.push_front(tracker.track(6)), true);
     assert_buf_eq!(buf, [6, 5, 4, 3]);
     tracker.assert_all_alive([3, 4, 5, 6]);
     tracker.assert_all_dropped([1, 2]);
 
-    buf.push_front(tracker.track(7));
+    assert_eq!(buf.push_front(tracker.track(7)), true);
     assert_buf_eq!(buf, [7, 6, 5, 4]);
     tracker.assert_all_alive([4, 5, 6, 7]);
     tracker.assert_all_dropped([1, 2, 3]);
 
-    buf.push_front(tracker.track(8));
+    assert_eq!(buf.push_front(tracker.track(8)), true);
     assert_buf_eq!(buf, [8, 7, 6, 5]);
     tracker.assert_all_alive([5, 6, 7, 8]);
     tracker.assert_all_dropped([1, 2, 3, 4]);


### PR DESCRIPTION
The two `push_*` functions may change what is at an index if the buffer was at capacity before the push.

Example:
```rust
let mut buffer: CircularBuffer<3, u8> = CircularBuffer::new();

buffer.push_back(1);
buffer.push_back(2);
assert_eq!(buffer, [1, 2]);
dbg!(buffer.get(1)); // = 2

buffer.push_back(3);
assert_eq!(buffer, [1, 2, 3]);
dbg!(buffer.get(1)); // = 2

// We just pushed again, but index 1 still points to `2`

buffer.push_back(4);
assert_eq!(buffer, [2, 3, 4]);
dbg!(buffer.get(1)); // = 3

// After pushing again, index 1 now points to `3`
// We have no way to tell if index 1's value changed unless we checked `is_full` before pushing
```

Because the index is affected by pushes only if the buffer was at capacity, I think it makes sense for `push_back` and `push_front` to return a value indicating whether they had to drop an element.

This makes it easier for users, instead of having to check `is_full` every time before pushing.

Thank you for this library! You're welcome to close this PR if you feel that it doesn't fit in with the intentions of the crate. I understand that not everyone needs to use the indexing.