### PR TITLE
fix `range` and `range_mut` for empty range

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -194,6 +194,10 @@ pub struct Iter<'a, T> {
 }
 
 impl<'a, T> Iter<'a, T> {
+    pub(crate) const fn empty() -> Self {
+        Self { right: &[], left: &[] }
+    }
+
     unstable_const_fn! {
         pub(crate) const fn new<{const N: usize}>(buf: &'a CircularBuffer<N, T>) -> Self {
             let (right, left) = buf.as_slices();
@@ -205,10 +209,14 @@ impl<'a, T> Iter<'a, T> {
         where R: RangeBounds<usize>
     {
         let (start, end) = translate_range_bounds(buf, range);
-        let mut it = Self::new(buf);
-        it.advance_front_by(start);
-        it.advance_back_by(end - start);
-        it
+        if start >= end {
+            Self::empty()
+        } else {
+            let mut it = Self::new(buf);
+            it.advance_front_by(start);
+            it.advance_back_by(end - start);
+            it
+        }
     }
 
     fn advance_front_by(&mut self, count: usize) {
@@ -296,6 +304,12 @@ pub struct IterMut<'a, T> {
 
 impl<'a, T> IterMut<'a, T> {
     unstable_const_fn! {
+        pub(crate) const fn empty() -> Self {
+            Self { right: &mut [], left: &mut [] }
+        }
+    }
+
+    unstable_const_fn! {
         pub(crate) const fn new<{const N: usize}>(buf: &'a mut CircularBuffer<N, T>) -> Self {
             let (right, left) = buf.as_mut_slices();
             Self { right, left }
@@ -306,10 +320,14 @@ impl<'a, T> IterMut<'a, T> {
         where R: RangeBounds<usize>
     {
         let (start, end) = translate_range_bounds(buf, range);
-        let mut it = Self::new(buf);
-        it.advance_front_by(start);
-        it.advance_back_by(end - start);
-        it
+        if start >= end {
+            Self::empty()
+        } else {
+            let mut it = Self::new(buf);
+            it.advance_front_by(start);
+            it.advance_back_by(end - start);
+            it
+        }
     }
 
     fn advance_front_by(&mut self, count: usize) {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -658,6 +658,12 @@ fn range() {
     assert_eq!(iter.next(), None);
 
     let buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
+    let mut iter = buf.range(0..0);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+
+    let buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
     let mut iter = buf.range((Bound::Excluded(4), Bound::Unbounded));
     assert_eq!(iter.next(), Some(&'f'));
     assert_eq!(iter.next(), Some(&'g'));
@@ -680,6 +686,18 @@ fn range() {
     assert_eq!(iter.next(), Some(&'d'));
     assert_eq!(iter.next(), Some(&'e'));
     assert_eq!(iter.next(), Some(&'f'));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+
+    let buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
+    let mut iter = buf.range((Bound::Excluded(2), Bound::Excluded(3)));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+
+    let buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
+    let mut iter = buf.range((Bound::Excluded(2), Bound::Included(2)));
     assert_eq!(iter.next(), None);
     assert_eq!(iter.next(), None);
     assert_eq!(iter.next(), None);
@@ -753,6 +771,12 @@ fn range_mut() {
     assert_eq!(iter.next(), None);
 
     let mut buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
+    let mut iter = buf.range_mut(0..0);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+
+    let mut buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
     let mut iter = buf.range_mut((Bound::Excluded(4), Bound::Unbounded));
     assert_eq!(iter.next(), Some(&mut 'f'));
     assert_eq!(iter.next(), Some(&mut 'g'));
@@ -775,6 +799,18 @@ fn range_mut() {
     assert_eq!(iter.next(), Some(&mut 'd'));
     assert_eq!(iter.next(), Some(&mut 'e'));
     assert_eq!(iter.next(), Some(&mut 'f'));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+
+    let mut buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
+    let mut iter = buf.range_mut((Bound::Excluded(2), Bound::Excluded(3)));
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+    assert_eq!(iter.next(), None);
+
+    let mut buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
+    let mut iter = buf.range_mut((Bound::Excluded(2), Bound::Included(2)));
     assert_eq!(iter.next(), None);
     assert_eq!(iter.next(), None);
     assert_eq!(iter.next(), None);


### PR DESCRIPTION
Thanks for the nice crate!

I noticed some weird behavior for the `range` and `range_mut` iterators when given an empty range.

For an empty range,
```rust
let buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
let mut data = buf.range(0..0).collect::<Vec<_>>();
assert_eq!(data, Vec::<&char>::new());
```
I would have expected this to return an empty iterator, but it returns the complete buffer:
```
assertion `left == right` failed
  left: ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']
 right: []
```

If the index of the empty range is changed, so does the output:
```rust
 let buf = CircularBuffer::<8, char>::from_iter("abcdefgh".chars());
 let mut data = buf.range(5..5).collect::<Vec<_>>();
 assert_eq!(data, Vec::<&char>::new());
```

```
 assertion `left == right` failed
  left: ['f', 'g', 'h']
 right: []
```

I guess that this is not the intended behavior.

This PR changes the behavior to return an empty iterator in case of an empty range with equal start and end. This way this replicates the same behavior as slicing (`&[0,1,2,3][0..0] == &[]`). Similarly slicing with a "reverse" range (`&[0,1,2,3][1..0]`) does panic, which `range` and `range_mut` already do.

(Also: I seems `rustfmt` does not seem to be applied, or you have a `rustfmt.toml` thats not checked in. I haven't included any of it here, but it might be also be worth fixing, so that one does not get a huge diff from the IDE.)