### PR TITLE
Panicking and checked push methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is a Rust crate that implements a [circular buffer], also known as cyclic
 buffer, circular queue or ring.
 
 This circular buffer has a fixed maximum capacity, does not automatically grow,
-and once its maximum capacity is reached, elements at the start of the buffer
+and by default once its maximum capacity is reached, elements at the start of the buffer
 are overwritten. It's useful for implementing fast FIFO (_first in, first out_)
 and LIFO (_last in, first out_) queues with a fixed memory capacity.
 


### PR DESCRIPTION
Hi,

I've added `push_(front|back)_or_panic` and `try_push_(front|back)` methods that panic or return error instead of overwriting the buffer.

Panicking allows to validate the expected invariant that the buffer shouldn't overflow. Checked versions could be used to implement backpressure and postpone elements queuing.