### PR TITLE
Make the crate more no_std friendly by using `alloc` and `core` instead of `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ categories = ["data-structures", "no-std"]
 
 [features]
 default = ["use_std"]
-use_std = []
+use_std = ["alloc"]
+alloc = []
 unstable = []
 
 [dependencies]

--- a/src/debug.rs
+++ b/src/debug.rs
@@ -1,4 +1,4 @@
-use std::fmt;
+use core::fmt;
 
 impl<const N: usize, T> Debug for CircularBuffer<N, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/src/drain.rs
+++ b/src/drain.rs
@@ -11,7 +11,7 @@ use crate::add_mod;
 use crate::iter::Iter;
 use crate::iter::translate_range_bounds;
 
-/// A draining [iterator](std::iter::Iterator) that removes and returns elements from a
+/// A draining [iterator](core::iter::Iterator) that removes and returns elements from a
 /// `CircularBuffer`.
 ///
 /// This struct is created by [`CircularBuffer::drain()`]. See its documentation for more details.

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -4,7 +4,7 @@ use core::ops::Bound;
 use core::ops::RangeBounds;
 use crate::CircularBuffer;
 
-/// An owning [iterator](std::iter::Iterator) over the elements of a [`CircularBuffer`].
+/// An owning [iterator](core::iter::Iterator) over the elements of a [`CircularBuffer`].
 ///
 /// This yields the elements of a `CircularBuffer` from fron to back.
 ///
@@ -183,7 +183,7 @@ fn slice_take_last_mut<'a, T>(slice: &mut &'a mut [T]) -> Option<&'a mut T> {
     Some(item)
 }
 
-/// An [iterator](std::iter::Iterator) over the elements of a `CircularBuffer`.
+/// An [iterator](core::iter::Iterator) over the elements of a `CircularBuffer`.
 ///
 /// This struct is created by [`CircularBuffer::iter()`] and [`CircularBuffer::range()`]. See
 /// their documentation for more details.
@@ -305,7 +305,7 @@ impl<'a, T> fmt::Debug for Iter<'a, T>
     }
 }
 
-/// A mutable [iterator](std::iter::Iterator) over the elements of a `CircularBuffer`.
+/// A mutable [iterator](core::iter::Iterator) over the elements of a `CircularBuffer`.
 ///
 /// This struct is created by [`CircularBuffer::iter_mut()`] and [`CircularBuffer::range_mut()`].
 /// See their documentation for more details.


### PR DESCRIPTION
Hello !

When I tried to use this crate in my project, I noticed that it use `std` imports which some could be replaced by `core` or `alloc` imports.

I make a quick PR to fix this by adding a feature flag (`alloc`) that will make more functions available for projects using `#[no_std]` but still using `alloc` crate (for example, kernel projects).