### PR TITLE
Use futures_lite directly instead of smol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ embedded-io-async = { version = "0.6", default-features = false, optional = true
 criterion = { version = "0.3", features = ["html_reports"] }
 drop-tracker = { version = "0.1.3" }
 rand = { version = "0.8" }
-smol = { version = "2.0", default-features = false }
+futures-lite = { version = "2.0" }
 
 [[bench]]
 name = "benchmark"

--- a/tests/io.rs
+++ b/tests/io.rs
@@ -164,7 +164,7 @@ mod embedded_io_async {
 
     #[test]
     fn write() {
-        smol::block_on(async {
+        futures_lite::block_on(async {
             let mut buf = CircularBuffer::<4, u8>::new();
             assert_eq!(buf, [] as [u8; 0]);
 
@@ -177,7 +177,7 @@ mod embedded_io_async {
 
     #[test]
     fn read() {
-        smol::block_on(async {
+        futures_lite::block_on(async {
             async fn read_all<R: Read>(mut buf: R) -> Vec<u8> {
                 let mut vec = Vec::new();
                 loop {
@@ -214,7 +214,7 @@ mod embedded_io_async {
 
     #[test]
     fn read_buf() {
-        smol::block_on(async {
+        futures_lite::block_on(async {
             let mut buf = CircularBuffer::<4, u8>::new();
             assert_eq!(buf, [] as [u8; 0]);
             assert_eq!(buf.fill_buf().await.unwrap(), b"");


### PR DESCRIPTION
The `smol::block_on` function is just a re-export of `futures_lite::block_on`, but `smol` also re-exports APIs from quite a few other crates that we don’t need. Using `futures-lite` directly lightens the dev-dependencies.

As the primary maintainer of the [`rust-circular-buffer` package](https://src.fedoraproject.org/rpms/rust-circular-buffer) in Fedora, this makes my life easier because we don’t have the entire smol-rs stack packaged, and so far we haven’t needed to. We do already have `futures-lite` and several of the common `async-*` crates.