### PR TITLE
Update a couple of dev-dependencies across SemVer boundaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ embedded-io-async = { version = "0.6", default-features = false, optional = true
 criterion = { version = "0.7.0" }
 drop-tracker = { version = "0.2.0" }
 futures-lite = { version = "2.6" }
-rand = { version = "0.9.2" }
+rand = { version = "0.10.1" }
 
 [[bench]]
 name = "benchmark"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ embedded-io-async = { version = "0.6", default-features = false, optional = true
 
 [dev-dependencies]
 criterion = { version = "0.7.0" }
-drop-tracker = { version = "0.1.3" }
+drop-tracker = { version = "0.2.0" }
 futures-lite = { version = "2.6" }
 rand = { version = "0.9.2" }
 

--- a/tests/randomized.rs
+++ b/tests/randomized.rs
@@ -14,7 +14,7 @@
 use circular_buffer::CircularBuffer;
 use drop_tracker::DropItem;
 use drop_tracker::DropTracker;
-use rand::Rng;
+use rand::{Rng, RngExt};
 use rand::distr::Distribution;
 use rand::distr::StandardUniform;
 use rand::distr::Uniform;


### PR DESCRIPTION
Update `drop-tracker` dev-dependency from 0.1.3. to 0.2.0

https://github.com/andreacorbellini/rust-drop-tracker/compare/v0.1.3...v0.2.0

Changes are only MSRV, Edition, and documentation.

----

Update rand dev-dependency from 0.9.2 to 0.10.1

https://github.com/rust-random/rand/blob/0.10.1/CHANGELOG.md

A tiny source-code change was required.